### PR TITLE
fix: update deprecated docker image for java

### DIFF
--- a/java/registry/docker-compose.yml
+++ b/java/registry/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   registry:
-    image: frolvlad/alpine-oraclejdk8:slim
+    image: frolvlad/alpine-java:jdk8-slim
     deploy:
       replicas: 1
     ports:


### PR DESCRIPTION
The `image: frolvlad/alpine-oraclejdk8:slim` docker image has been [deprecated ](https://github.com/Docker-Hub-frolvlad/docker-alpine-java)due to Oracle Java's change in license. This causes the `docker-compose up` command to fail.

The maintainer has recommended a switch to `frolvlad/alpine-java:jdk8-slim`, which causes the container to start as originally intended.