### PR TITLE
no-args check, default schema generation on args

### DIFF
--- a/configure-dependencies.sh
+++ b/configure-dependencies.sh
@@ -3,18 +3,19 @@ echo "Configuring dependencies before build"
 cp java/registry/src/main/resources/application.yml.sample java/registry/src/main/resources/application.yml
 cp java/registry/src/main/resources/frame.json.sample java/registry/src/main/resources/frame.json
 
-if "$1" == "true":
-then
+if [ $# -gt 0 ] && "$1" == "true"; then
  default_schema=true
 else
  default_schema=false
 fi
 
+echo "Using default schema: $default_schema"
+
 schema_dir='java/registry/src/main/resources/public/_schemas'
 schema_sample_dir='java/registry/src/main/resources/public/_schemas_sample'
 
-if $defaul_schema
-then
+if [ "$default_schema" = true ]; then
+  mkdir -p "$schema_dir"
   for file in "$schema_sample_dir"/*; do
     old_file="$(basename "$file")"
     


### PR DESCRIPTION
Added check if no arguments are provided, defaults to _false_. 

Prevent default schema generation if argument is _false_. 

Automatically creates schema directory to prevent "no such file or directory" error if argument is _true_.